### PR TITLE
Use Scala string interpolation for log messages

### DIFF
--- a/simple-anonymizer/src/scala/simpleanonymizer/CopyAction.scala
+++ b/simple-anonymizer/src/scala/simpleanonymizer/CopyAction.scala
@@ -78,11 +78,11 @@ private[simpleanonymizer] class CopyAction(
         limit.fold("")(n => s" LIMIT $n")
     }
 
-    logger.debug("SELECT: {}", selectSql)
+    logger.debug(s"SELECT: $selectSql")
 
     val totalRowsFut = sourceDbContext.db.run(sql"SELECT count(*) FROM (#$selectSql) t".as[Int].head)
-    totalRowsFut.foreach(n => logger.info("Table {} has {} rows", tableName, n))
-    logger.info("Copying table: {}", tableName)
+    totalRowsFut.foreach(n => logger.info(s"Table $tableName has $n rows"))
+    logger.info(s"Copying table: $tableName")
 
     val insertSql = {
       val columnList                                                              = columns.map(c => quoteIdentifier(c._1.name)).mkString(", ")
@@ -212,7 +212,7 @@ object CopyAction {
         buffer.clear()
         val now = System.currentTimeMillis()
         if (now - lastLogTime >= 5000) {
-          logger.info("Inserted {}{} rows into {}...", count, totalSuffix, quotedTable)
+          logger.info(s"Inserted $count$totalSuffix rows into $quotedTable...")
           lastLogTime = now
         }
       }
@@ -223,7 +223,7 @@ object CopyAction {
       try {
         if (buffer.nonEmpty)
           count += insertBatch(buffer.toVector)
-        logger.info("Copied {}{} rows from {}", count, totalSuffix, quotedTable)
+        logger.info(s"Copied $count$totalSuffix rows from $quotedTable")
         count
       } finally
         stmt.close()

--- a/simple-anonymizer/src/scala/simpleanonymizer/DbContext.scala
+++ b/simple-anonymizer/src/scala/simpleanonymizer/DbContext.scala
@@ -25,7 +25,7 @@ class DbContext(val db: Database, val schema: String)(implicit ec: ExecutionCont
     db.run(
       MTable.getTables(None, Some(schema), None, Some(Seq("TABLE"))).map(_.sortBy(_.name.name))
     ).map { tables =>
-      logger.info("Found {} tables.", tables.size)
+      logger.info(s"Found ${tables.size} tables.")
       tables
     }
   }
@@ -36,7 +36,7 @@ class DbContext(val db: Database, val schema: String)(implicit ec: ExecutionCont
     db.run(
       MForeignKey.getImportedKeys(MQName(None, Some(schema), null))
     ).map { fks =>
-      logger.info("Found {} foreign keys.", fks.size)
+      logger.info(s"Found ${fks.size} foreign keys.")
       fks
     }
   }
@@ -91,7 +91,7 @@ class DbContext(val db: Database, val schema: String)(implicit ec: ExecutionCont
           AND d.deptype IN ('a', 'i')
       """.as[DbContext.SequenceInfo]
     ).map { seqs =>
-      logger.info("Found {} sequences.", seqs.size)
+      logger.info(s"Found ${seqs.size} sequences.")
       seqs
     }
   }

--- a/simple-anonymizer/src/scala/simpleanonymizer/DbCopier.scala
+++ b/simple-anonymizer/src/scala/simpleanonymizer/DbCopier.scala
@@ -56,7 +56,7 @@ class DbCopier(sourceDb: Database, targetDb: Database, schema: String = "public"
       specs: Map[String, TableSpec]
   ): Future[Map[String, Int]] = {
     val totalTables = levels.map(_.size).sum
-    logger.info("Copying {} tables in {} levels...", totalTables, levels.size)
+    logger.info(s"Copying $totalTables tables in ${levels.size} levels...")
 
     levels.foldLeft(Future.successful(Map.empty[String, Int])) { (accFut, level) =>
       accFut.flatMap { acc =>
@@ -66,7 +66,7 @@ class DbCopier(sourceDb: Database, targetDb: Database, schema: String = "public"
         val futures = level.map { table =>
           val tableName = table.name.name
           if (skippedTables.contains(tableName)) {
-            logger.info("Skipping table: {}", tableName)
+            logger.info(s"Skipping table: $tableName")
             Future.successful(tableName -> 0)
           } else
             tableCopier

--- a/simple-anonymizer/src/scala/simpleanonymizer/Lens.scala
+++ b/simple-anonymizer/src/scala/simpleanonymizer/Lens.scala
@@ -48,7 +48,7 @@ object Lens {
     protected def modifyJson(f: String => String): Json => Json = { json =>
       json.asString match {
         case None      =>
-          logger.warn("Expected string but got {}", json.name)
+          logger.warn(s"Expected string but got ${json.name}")
           json
         case Some(str) =>
           val transformed = f(str)
@@ -63,7 +63,7 @@ object Lens {
       parse(jsonStr) match {
         case Right(json) => modifyJson(f)(json).noSpaces
         case Left(err)   =>
-          logger.warn("Failed to parse JSON: {}", err.message)
+          logger.warn(s"Failed to parse JSON: ${err.message}")
           jsonStr
       }
     }
@@ -85,7 +85,7 @@ object Lens {
     protected def modifyJson(f: String => String): Json => Json = { json =>
       json.asObject match {
         case None      =>
-          logger.warn("Expected object but got {}", json.name)
+          logger.warn(s"Expected object but got ${json.name}")
           json
         case Some(obj) =>
           obj(fieldName) match {
@@ -93,7 +93,7 @@ object Lens {
               val transformed = inner.modifyJson(f)(fieldValue)
               obj.add(fieldName, transformed).asJson
             case None             =>
-              logger.warn("Field '{}' not found in JSON object", fieldName)
+              logger.warn(s"Field '$fieldName' not found in JSON object")
               json
           }
       }
@@ -109,7 +109,7 @@ object Lens {
     protected def modifyJson(f: String => String): Json => Json = { json =>
       json.asArray match {
         case None      =>
-          logger.warn("Expected array but got {}", json.name)
+          logger.warn(s"Expected array but got ${json.name}")
           json
         case Some(arr) =>
           val transformed = arr.map(elementLens.modifyJson(f))

--- a/simple-anonymizer/src/scala/simpleanonymizer/SelfRefConstraints.scala
+++ b/simple-anonymizer/src/scala/simpleanonymizer/SelfRefConstraints.scala
@@ -41,7 +41,7 @@ private[simpleanonymizer] class SelfRefConstraints(db: Database, schema: String,
         val selfRefFks = allFks.filter(fk => fk.pkTable.name == fk.fkTable.name)
 
         if (selfRefFks.nonEmpty)
-          logger.info("Self-ref constraints for {}: {}", tableName, selfRefFks.flatMap(_.fkName).mkString(", "))
+          logger.info(s"Self-ref constraints for $tableName: ${selfRefFks.flatMap(_.fkName).mkString(", ")}")
 
         selfRefFks
       }

--- a/simple-anonymizer/src/scala/simpleanonymizer/TableCopier.scala
+++ b/simple-anonymizer/src/scala/simpleanonymizer/TableCopier.scala
@@ -43,7 +43,7 @@ class TableCopier(source: DbContext, val target: DbContext)(implicit ec: Executi
 
     val transformedColumns = tableSpec.columns.collect { case c if !c.isInstanceOf[OutputColumn.SourceColumn] => c.name }
     if (transformedColumns.nonEmpty)
-      logger.info("Transforming columns of {}: {}", tableName, transformedColumns.mkString(", "))
+      logger.info(s"Transforming columns of $tableName: ${transformedColumns.mkString(", ")}")
 
     selfRefConstraints.restoringDeferrability { constraints =>
       for {
@@ -78,7 +78,7 @@ class TableCopier(source: DbContext, val target: DbContext)(implicit ec: Executi
                 .head
             )
             .map { newVal =>
-              logger.info("Reset sequence {} to {} for {}.{}", seq.sequenceName, newVal, tableName, seq.columnName)
+              logger.info(s"Reset sequence ${seq.sequenceName} to $newVal for $tableName.${seq.columnName}")
             }
         }
         .map(_ => ())

--- a/simple-anonymizer/src/scala/simpleanonymizer/TableSorter.scala
+++ b/simple-anonymizer/src/scala/simpleanonymizer/TableSorter.scala
@@ -57,8 +57,7 @@ object TableSorter {
         if (newlyAssigned.isEmpty) {
           // Circular dependency detected - no progress possible
           logger.warn(
-            "Circular dependencies detected for tables: {}. These tables will not be copied.",
-            unassigned.mkString(", ")
+            s"Circular dependencies detected for tables: ${unassigned.mkString(", ")}. These tables will not be copied."
           )
           levels
         } else


### PR DESCRIPTION
## Summary
- Replace SLF4J `{}` placeholder logging with Scala `s"..."` string interpolation across 7 files
- More idiomatic Scala style while preserving identical log output

## Test plan
- [x] `bleep compile` passes (both Scala 2.13 and Scala 3)
- [x] `bleep fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)